### PR TITLE
fix(css): remove invalid theme inline

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,9 @@
   --foreground: #171717;
 }
 
-@theme inline {
+:root {
+  --background: #ffffff;
+  --foreground: #171717;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);


### PR DESCRIPTION
- src/app/globals.css:
  - replace theme inline block with :root selector
  - move background and foreground variable definitions to :root
  - set color variables to reference new root variables