### PR TITLE
feat(profile): handle discord api rate limiting

### DIFF
--- a/src/app/components/profile/DiscordProfile.tsx
+++ b/src/app/components/profile/DiscordProfile.tsx
@@ -168,7 +168,10 @@ export default function DiscordProfile({
     }, [apiEndpoint, userId, onLoadingStateChange]);
 
     const handleStatusUpdate = useCallback((newStatus: string) => {
-        if (newStatus !== status) {
+        if (newStatus && newStatus !== status) {
+            if (process.env.NODE_ENV !== 'production') {
+                console.log(`Updating Discord status for user ${userId}:`, status, '->', newStatus);
+            }
             setStatus(newStatus);
 
             const cached = avatarCache.get(userId);


### PR DESCRIPTION
- src/app/components/hooks/useDiscordPolling.ts:
  - add onRateLimited callback to options
  - stop polling on 429 rate limit and trigger callback
- src/app/components/hooks/useDiscordSocket.ts:
  - add onRateLimited callback to options
  - trigger callback when rate limit error occurs
- src/app/components/profile/DiscordProfile.tsx:
  - track and handle rate limited state
  - update UI to hide status when rate limited
  - use backup avatar and offline status on rate limit